### PR TITLE
Mitigate issue #3

### DIFF
--- a/scripts/setup_gemdaq.sh
+++ b/scripts/setup_gemdaq.sh
@@ -3,7 +3,22 @@
 if ! $(return >/dev/null 2>&1);
 then
     echo >&2 "ERROR: You must use \"source $0\" to run this script."
-    exit 1
+
+    # Unfortunately the detection isn't reliable. Try to get more information
+    echo >&2
+    echo >&2 "If you used \"source $0\", please add a comment here:"
+    echo >&2 "    https://github.com/cms-gem-daq-project/sw_utils/issues/3"
+    echo >&2 "I generated some debugging information for you in $PWD/setup_gemdaq.debug"
+    echo >&2 "Please add it to your comment."
+
+    echo "ENV:\n" >$PWD/setup_gemdaq.debug
+    env >>$PWD/setup_gemdaq.debug
+    echo "\nSHELL OPTIONS: $-" >>$PWD/setup_gemdaq.debug
+
+    $(return >/dev/null 2>&1)
+    echo "\nRET STATUS: $?" >>$PWD/setup_gemdaq.debug
+
+    kill -INT $$
 fi
 
 if [[ ! "$0" =~ ("bash") ]];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Sometimes, setup_gemdaq.sh doesn't detect that it's being sourced and exits the calling shell.

* Use `kill -INT $$` instead of `exit`. This doesn't exit an existing session and terminates sourced scripts correctly
* Generate some information and ask the user to attach it to #3 in order to get more information and eventually fix detection

#3 shouldn't be closed after merging this PR.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (kind of) (non-breaking change which fixes an issue)
- [x] New feature (kind of too) (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
#3

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Checked that `kill -INT $$` exits from a sourced script for both `bash` and `zsh` without terminating the calling shell
* Checked that `kill -INT $$` exits from an executed script for both `bash` and `zsh`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
