### PR TITLE
Fix bug #3

### DIFF
--- a/scripts/setup_gemdaq.sh
+++ b/scripts/setup_gemdaq.sh
@@ -1,23 +1,11 @@
 # Detect when we're not being sourced, print a hint and exit
 # Based on https://stackoverflow.com/questions/2683279/how-to-detect-if-a-script-is-being-sourced#34642589
-if ! $(return >/dev/null 2>&1);
+# When "return" fails (ie if not sourced), an error message is printed and
+# caught by the if clause.
+# In the normal mode of operation (ie if sourced), "return" is silent
+if [[ ! -z "$(return 2>&1)" ]];
 then
     echo >&2 "ERROR: You must use \"source $0\" to run this script."
-
-    # Unfortunately the detection isn't reliable. Try to get more information
-    echo >&2
-    echo >&2 "If you used \"source $0\", please add a comment here:"
-    echo >&2 "    https://github.com/cms-gem-daq-project/sw_utils/issues/3"
-    echo >&2 "I generated some debugging information for you in $PWD/setup_gemdaq.debug"
-    echo >&2 "Please add it to your comment."
-
-    echo "ENV:\n" >$PWD/setup_gemdaq.debug
-    env >>$PWD/setup_gemdaq.debug
-    echo "\nSHELL OPTIONS: $-" >>$PWD/setup_gemdaq.debug
-
-    $(return >/dev/null 2>&1)
-    echo "\nRET STATUS: $?" >>$PWD/setup_gemdaq.debug
-
     kill -INT $$
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When the last command issued before sourcing setup_gemdaq.sh had failed,
the detection of "not-sourced" operation was failing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
#3, in particular https://github.com/cms-gem-daq-project/sw_utils/issues/3#issuecomment-399437692

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Failing before the change:

```
[lmoureau@lxplus096 GEM]$ (exit 1); source sw_utils/scripts/setup_gemdaq.sh
ERROR: You must use "source -bash" to run this script.

If you used "source -bash", please add a comment here:
    https://github.com/cms-gem-daq-project/sw_utils/issues/3
I generated some debugging information for you in /afs/cern.ch/user/l/lmoureau/GEM/setup_gemdaq.debug
Please add it to your comment.
```

### Normal behavior after the change:
```
[lmoureau@lxplus096 GEM]$ (exit 1); source sw_utils/scripts/setup_gemdaq.sh 
ELOG_PATH not set, please set ELOG_PATH to a directory where plots created by analysis applications will be written
 (export ELOG_PATH=<your>/<elog>/<directory>/) and then rerun this script
```

### Also works if the previous command didn't fail:
```
[lmoureau@lxplus096 GEM]$ (exit 0); source sw_utils/scripts/setup_gemdaq.sh 
ELOG_PATH not set, please set ELOG_PATH to a directory where plots created by analysis applications will be written
 (export ELOG_PATH=<your>/<elog>/<directory>/) and then rerun this script
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
