### PR TITLE
Add instructions for preparing a power cut

### DIFF
--- a/v3ElectronicsUserGuide.md
+++ b/v3ElectronicsUserGuide.md
@@ -738,15 +738,15 @@ cd /mnt/persistent/gemdaq/gemloader
 
 ## Preparing For a Power Cut
 
-In order to safely prepare a GEM test stand before a planned power cut execute:
+In order to safely prepare a GEM test stand for a planned power cut execute:
 
  1. Power down the High Voltage.
-     - Use the opportunity to power down other sensitive equipement such as PMT's.
+     - Use the opportunity to power down other sensitive equipment, such as PMT's.
  2. Power down the Low Voltage.
  3. Place the µTCA modules in extraction mode:
-     - Gently pull the hot swap tab on the AMC's (CTP7 and AMC13). Wait until the blue LED stays on solid on each AMC's.
+     - Gently pull the hot swap tab on all AMC's, including the AMC13. Wait until the blue LED stays on solid on each AMC's.
      - Gently pull the hot swap tab on the MCH. Again, wait until the blue LED stays solid on.
- 5. Power down the µTCA crate Power Modules one at a time. If powered with AC/DC converters, simply flip the switch on the AC/DC one at a time.
+ 5. Power down the µTCA crate Power Modules one at a time. Find the AC/DC converters powering the PM's and turn them off one at a time. They can either be built in the crate or external to the crate. In the first case, a switch is present on the crate front panel.
  6. Finally, power off the DAQ computer.
 
 ## Recovering From a Power Cut
@@ -756,12 +756,12 @@ To recover a GEM test stand after a power cut execute:
  1. Ensure the uTCA crate and associated hardware all have power.
      - E.g. the crate, network switches, DAQ computer, etc...
  2. Start the DAQ computer first, then:
-     - Ensure that the `sysmgr`, `xinetd` and `dnsmasq` services are correctly started. You can use the `systemctl status <service name> command to check each service status. The `Active` field must report `active (running)`.
+     - Ensure that the `sysmgr`, `xinetd` and `dnsmasq` services are correctly started. You can use the `systemctl status <service name>` command to check each service status. The `Active` field must report `active (running)`.
      - If any of the services is not started, you can start it manually with the following command `sudo systemctl start <service name>`.
  3. Power on the µTCA crate. If the power cut was planned, undo the actions from the [previous section](#preparing-for-a-power-cut):
      - Power on the µTCA crate Power Modules one at a time.
      - Push the hot swap tab on the MCH and wait for the blue LED to turn off.
-     - Push the hot swap tabs on the AMC's and wait for the blue LED's to turn off.
+     - Push the hot swap tabs on the AMC's, including the AMC13, and wait for the blue LED's to turn off.
  4. Enter the AMC13 tool and enable clocks to the AMC of interest by following instructions under [Enabling Clock to an AMC Slot](#enabling-clock-to-an-amc-slot),
  5. For each CTP7 login as `texas` and execute: `killall rpcsvc`
      - Right now on boot the CTP7 linux core will start `rpcsvc` as the `texas` user and this is not gauranteed to have the correct `$ENV` for the `rpcmodules` on the card.

--- a/v3ElectronicsUserGuide.md
+++ b/v3ElectronicsUserGuide.md
@@ -31,6 +31,7 @@ Table of Contents
                * [v3 Hardware](#v3-hardware)
             * [Full Recovery: recover.sh](#full-recovery-recoversh)
          * [To Update OH FW on CTP7](#to-update-oh-fw-on-ctp7)
+      * [Preparing For a Power Cut](#preparing-for-a-power-cut)
       * [Recovering From a Power Cut](#recovering-from-a-power-cut)
    * [Front-end Electronics](#front-end-electronics)
       * [LV Power](#lv-power)
@@ -734,6 +735,19 @@ cd /mnt/persistent/gemdaq/gemloader
  30. To confirm that the update was successful reprogram all optohybrids following instructions under [Programming OH FPGA](#programming-oh-fpga).
     - Note this will kill any running process on the hardware, but if you're updating FW no one should be using the system anyway.
  31.  Summarize the actions you took in the elog entry you have already opened.
+
+## Preparing For a Power Cut
+
+In order to safely prepare a GEM test stand before a planned power cut execute:
+
+ 1. Power down the High Voltage.
+     - Use the opportunity to power down other sensitive equipement such as PMT's.
+ 2. Power down the Low Voltage.
+ 3. Place the µTCA modules in extraction mode:
+     - Gently pull the hot swap tab on the AMC's (CTP7 and AMC13). Wait until the blue LED stays on solid on each AMC's.
+     - Gently pull the hot swap tab on the MCH. Again, wait until the blue LED stays solid on.
+ 5. Power down the µTCA crate Power Modules one at a time. If powered with AC/DC converters, simply flip the switch on the AC/DC one at a time.
+ 6. Finally, power off the DAQ computer.
 
 ## Recovering From a Power Cut
 

--- a/v3ElectronicsUserGuide.md
+++ b/v3ElectronicsUserGuide.md
@@ -753,15 +753,22 @@ In order to safely prepare a GEM test stand before a planned power cut execute:
 
 To recover a GEM test stand after a power cut execute:
 
- 1. Ensure the uTCA crate and associated hardware all have power
-     - E.g. the crate, all AMCs, network swtiches, DAQ computer, etc...
- 2. Enter the AMC13 tool and enable clocks to the AMC of interest by following instructions under [Enabling Clock to an AMC Slot](#enabling-clock-to-an-amc-slot),
- 3. For each CTP7 login as `texas` and execute: `killall rpcsvc`
+ 1. Ensure the uTCA crate and associated hardware all have power.
+     - E.g. the crate, network switches, DAQ computer, etc...
+ 2. Start the DAQ computer first, then:
+     - Ensure that the `sysmgr`, `xinetd` and `dnsmasq` services are correctly started. You can use the `systemctl status <service name> command to check each service status. The `Active` field must report `active (running)`.
+     - If any of the services is not started, you can start it manually with the following command `sudo systemctl start <service name>`.
+ 3. Power on the µTCA crate. If the power cut was planned, undo the actions from the [previous section](#preparing-for-a-power-cut):
+     - Power on the µTCA crate Power Modules one at a time.
+     - Push the hot swap tab on the MCH and wait for the blue LED to turn off.
+     - Push the hot swap tabs on the AMC's and wait for the blue LED's to turn off.
+ 4. Enter the AMC13 tool and enable clocks to the AMC of interest by following instructions under [Enabling Clock to an AMC Slot](#enabling-clock-to-an-amc-slot),
+ 5. For each CTP7 login as `texas` and execute: `killall rpcsvc`
      - Right now on boot the CTP7 linux core will start `rpcsvc` as the `texas` user and this is not gauranteed to have the correct `$ENV` for the `rpcmodules` on the card.
- 4. For each CTP7 login as `gemuser` and execute: `recover.sh`
+ 6. For each CTP7 login as `gemuser` and execute: `recover.sh`
      - Check to make sure `rpcsvc` is running as `gemuser` by executing `ps | grep rpcsvc`.  If `rpcsvc` is not running launch it manually as `gemuser` by executing: `rpcsvc`
      - Check to make sure `ipbus` is running as `gemuser` by executing `ps | grep ipbus`.  If `ipbus` is not running launch it manually as `gemuser` by executing: `ipbus`.
- 5. For each CTP7 from the DAQ machine try to read the FW address of the CTP7:
+ 7. For each CTP7 from the DAQ machine try to read the FW address of the CTP7:
      - Execute: `gem_reg.py`
      - From inside the `gem_reg.py` tool execute: `connect eagleXX` where `XX` is the number of the CTP7 of interest
      - From inside the `gem_reg.py` tool execute: `kw RELEASE` this should display the FW release of the CTP7, if `0xdeaddead` are shown for any entries of the CTP7 registers (e.g. those lines that do _**not**_ have `OHX` in the name for `X` some integer) the CTP7 is not programmed correctly.


### PR DESCRIPTION
Add the instructions for preparing a power cut as it was done at ULB on 19 November 2018.

Also add precisions about the recovery from a power cut. Some services must run on the DAQ machine and AMC's must be out of extraction mode.

## Description

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
We might need to safely power off a GEM stand in case of a planned power cut.

## How Has This Been Tested?

### Screenshots (if appropriate):

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
