### PR TITLE
New Feature: Utility scripts for running lightDQM & Latency Scans Manually

### DIFF
--- a/scripts/autoLatScan.sh
+++ b/scripts/autoLatScan.sh
@@ -1,0 +1,92 @@
+#!/bin/zsh
+
+helpstring="
+Automatically scans latency through a predefined range.  You must have started the run beforehand.
+    Usage:
+        autoLatScan.sh [options]
+        Options:
+            -a AMC slot in uTCA crate
+            -d Print additional debugging info
+            -h Display this message and exit
+            -l Latency range given as two numbers separated by a hyphen, e.g. 38-48
+            -o ohMask to use for this scan (a 1 in the N^th bit means use the N^th OH)
+            -s uTCA crate shelf number
+            -t Time to wait in seconds before changing the latency"
+
+# Set Defaults
+AMC=2
+DEBUG=$((0))
+LATRANGE="38-48"
+OHMASK=$((0xfff))
+SHELF=1
+TIME=300
+
+# Get Options
+OPTIND=1
+while getopts "a:l:o:s:t:hd" opts
+do
+    case $opts in
+        a) 
+            AMC="$OPTARG";;
+        l)
+            LATRANGE="$OPTARG";;
+        o)
+            OHMASK="$OPTARG";;
+        s)
+            SHELF="$OPTARG";;
+        t)
+            TIME="$OPTARG";;
+        d)
+            DEBUG=$((1));;
+        h)
+            echo >&2 "${helpstring}"
+            #return 1;;
+            kill -INT $$;;
+        \?)
+            echo >&2 "${helpstring}"
+            #return 1;;
+            kill -INT $$;;
+        [?])
+            echo >&2 "${helpstring}"
+            #return 1;;
+            kill -INT $$;;
+    esac
+done
+unset OPTIND
+
+RANGE_FIRST=$((-1))
+RANGE_LAST=$((-1))
+for substr in $(echo $LATRANGE | tr "-" "\n")
+do
+    if [ ${RANGE_FIRST} -lt 0 ]; then
+        RANGE_FIRST=$substr
+    elif [ $RANGE_LAST -lt 0 ]; then
+        RANGE_LAST=$substr
+    else
+    fi
+done
+
+if [ ${RANGE_FIRST} -lt 0 ]; then
+    echo "I was unable to determine the first latency point"
+    echo ${helpstring}
+    kill -INT $$
+fi
+
+if [ $RANGE_LAST -lt 0 ]; then
+    echo "I was unable to determine the last latency point"
+    echo ${helpstring}
+    kill -INT $$
+fi
+
+echo "Latency range of interest determined to be [$RANGE_FIRST,$RANGE_LAST]"
+echo "Scanning this range"
+for lat in {$RANGE_FIRST..$RANGE_LAST}
+do
+    echo "============================Latency ${lat}============================"
+    echo "set_scanParams_latency.py -s $AMC --shelf=${SHELF} ${lat} ${OHMASK}"
+    set_scanParams_latency.py -s $AMC --shelf=${SHELF} ${lat} ${OHMASK}
+    echo "Waiting $TIME seconds"
+    sleep $TIME
+done
+
+echo "Scan Complete; You may stop RCMS Now"

--- a/scripts/runLDQM.sh
+++ b/scripts/runLDQM.sh
@@ -4,7 +4,7 @@ helpstring="
 Individually processes chunk files found in $DATA_PATH/Cosmics (or provided -p argument) with the unpacker, adds the output raw.root files together, and then processes this final file with the light dqm.
         Usage: mergeFiles.sh [options]
         Options:
-            -d provide debugging information
+            -d Outputs commands that will be executed, nothing is produced
             -i initial chunk number to consider, defaults to 0
             -f final chunk number to consider, if not provided all chunk files will be processed
             -h prints this menu and exits

--- a/scripts/runLDQM.sh
+++ b/scripts/runLDQM.sh
@@ -1,0 +1,170 @@
+#!/bin/bash -e
+
+helpstring="
+Processes chunk files found in $DATA_PATH/Cosmics (or provided -p argument) with either the unpacker (flag -u) or the light dqm (flag -a).
+        Usage: mergeFiles.sh [options] [ -a | -u ]
+        Options:
+            -a the script will perform the dqm analysis
+            -d provide debugging information
+            -i initial chunk number to consider, defaults to 0
+            -f final chunk number to consider
+            -h prints this menu and exits
+            -p path to datafiles of the form 'runXXXXXX_Cosmic_CERNQC8_YYYY-MM-DD_chunk_*.dat'
+            -r run number of interest
+            -u the script will perform the unpacking"
+
+# Set Defaults
+ADDHISTOS=""
+CMD=""
+FILEPATH="$DATA_PATH/Cosmics"
+DEBUG=""
+OPTION=""
+RUNNUMBER=""
+FILEEXT=""
+INITIALCHUNK=$((0))
+FINALCHUNK=$((-1))
+
+# Get Options
+OPTIND=1
+while getopts ":p:r:i:f:hdau" opts
+do
+    case $opts in
+        a)
+            ADDHISTOS="true"
+            CMD="dqm"
+            FILEEXT="raw.root";;
+        p) 
+            FILEPATH="$OPTARG";;
+        r)
+            RUNNUMBER="$OPTARG";;
+        i)
+            INITIALCHUNK="$OPTARG";;
+        f)
+            FINALCHUNK="$OPTARG";;
+        u)
+            CMD="unpacker"
+            OPTION="sdram"
+            FILEEXT="dat";;
+        d)
+            DEBUG="true";;
+        h)
+            echo >&2 "${helpstring}"
+            #return 1;;
+            kill -INT $$;;
+        \?)
+            echo >&2 "${helpstring}"
+            #return 1;;
+            kill -INT $$;;
+        [?])
+            echo >&2 "${helpstring}"
+            #return 1;;
+            kill -INT $$;;
+    esac
+done
+unset OPTIND
+
+if [ -n "$DEBUG" ]
+then
+    echo 
+    echo CMD ${CMD}
+    echo FILEPATH ${FILEPATH}
+    echo OPTION ${OPTION}
+    echo RUNNUMBER ${RUNNUMBER}
+    echo FILEEXT ${FILEEXT}
+    echo INITIALCHUNK ${INITIALCHUNK}
+    echo FINALCHUNK ${FINALCHUNK}
+fi
+
+if [ -z "$CMD" ]
+then
+    echo "You must supply either option '-a' or '-u'"
+    echo ${helpstring}
+    kill -INT $$;
+fi
+
+# Create the run number string
+RUNSTRING=""
+if (( ${RUNNUMBER} > 99999 )); then
+    echo "true"
+    RUNSTRING="${RUNNUMBER}"
+elif (( ${RUNNUMBER} > 9999 )); then
+    RUNSTRING="0${RUNNUMBER}"
+elif (( ${RUNNUMBER} > 999 )); then
+    RUNSTRING="00${RUNNUMBER}"
+elif (( ${RUNNUMBER} > 99 )); then
+    RUNSTRING="000${RUNNUMBER}"
+elif (( ${RUNNUMBER} > 9 )); then
+    RUNSTRING="0000${RUNNUMBER}"
+else
+    RUNSTRING="00000${RUNNUMBER}"
+fi
+
+#OUTPUTFILENAME=$(ls ${FILEPATH}/run${RUNSTRING}_Cosmic_CERNQC8_*_chunk_*.dat | grep "chunk_0.dat")
+#OUTPUTFILENAME="${OUTPUTFILENAME%"_chunk_0.dat"}.dat"
+#
+#if [ -f ${OUTPUTFILENAME} ]; then
+#    echo "file ${OUTPUTFILENAME} exists already"
+#    echo "to prevent event duplication I am deleting it"
+#    echo "rm ${OUTPUTFILENAME}"
+#    rm ${OUTPUTFILENAME}
+#fi
+
+# Loop over files found in FILEPATH
+#for file in ${FILEPATH}/run${RUNSTRING}_Cosmic_CERNQC8_*_chunk_*.dat
+for file in ${FILEPATH}/run${RUNSTRING}_Cosmic_CERNQC8_*_chunk_*.${FILEEXT}
+do
+    chunkNumber=$(echo $file 2>/dev/null | awk -F _ '{ print $6 }' 2>/dev/null | awk -F . '{print $1}' )
+
+    # Skip chunk files below initial number
+    if (( ${chunkNumber} < ${INITIALCHUNK} )); then
+        if [ -n "$DEBUG" ]; then
+            echo "skipping chunk ${chunkNumber}"
+        fi
+        continue
+    fi
+
+    # Skip chunk files above final number if provided
+    if (( ${FINALCHUNK} -gt -1 )); then
+        if (( ${chunkNumber} > ${FINALCHUNK} )); then
+            if [ -n "$DEBUG" ]; then
+                echo "skipping chunk ${chunkNumber}"
+            fi
+            continue
+        fi
+    fi
+
+    #echo "cat ${file} >> ${OUTPUTFILENAME}"
+    #cat ${file} >> ${OUTPUTFILENAME} 
+    if [ -n "$DEBUG" ]; then
+        echo "${CMD} ${file} ${OPTION}"
+    else
+        echo "${CMD} ${file} ${OPTION}"
+        ${CMD} ${file} ${OPTION}
+    fi
+
+    if [ -n "$ADDHISTOS" ]; then
+        FILELIST="${FILELIST} ${file}"
+    fi 
+done
+
+if [ -n "$ADDHISTOS" ]; then
+    OUTPUTFILENAME=$(ls ${FILEPATH}/run${RUNSTRING}_Cosmic_CERNQC8_*_chunk_*.${FILEEXT} | grep "chunk_0.${FILEEXT}")
+    OUTPUTFILENAME="${OUTPUTFILENAME%"_chunk_0.{$FILEEXT}"}.${FILEEXT}"
+    
+    if [ -f ${OUTPUTFILENAME} ]; then
+        echo "file ${OUTPUTFILENAME} exists already; deleting it"
+        echo "rm ${OUTPUTFILENAME}"
+        rm ${OUTPUTFILENAME}
+    fi
+
+    echo ""
+    echo "hadd -k ${OUTPUTFILENAME} ${FILELIST}"
+    echo ""
+fi
+
+#echo ""
+#echo "Your file can be found at:"
+#echo ""
+#echo    ${OUTPUTFILENAME}
+#echo ""
+echo "Done"

--- a/scripts/setup_gemdaq.sh
+++ b/scripts/setup_gemdaq.sh
@@ -329,6 +329,10 @@ then
     export PATH=/opt/reg_utils/bin:$PATH
     export PATH=/opt/xhal/bin/:$PATH
 
+    # Add LDQM tools to PATH
+    export PATH=${BUILD_HOME}/gem-light-dqm/dqm-root/bin:$PATH
+    export PATH=${BUILD_HOME}/gem-light-dqm/gemtreewriter/bin:$PATH
+
     # Firmware
     export FIRMWARE_GEM=/data/bigdisk/GEMDAQ_Documentation/system/firmware/files
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I've added two new scripts for running `ldqm` and a latency scan by hand for v3 electronics.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
While `ldqm` has a `demon` it is sometimes necessary to run things by hand (or re-run).  So I've added a script:

 - `runLDQM.sh`

Additionally I've added a script for running a latency scan by hand:

 - `autoLatScan.sh`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Extensively during xtalk measurements.

### Example calls of `autoLatScan.sh`

Help menu:

```bash
% ./autoLatScan.sh -h 

Automatically scans latency through a predefined range.  You must have started the run beforehand.
    Usage:
        autoLatScan.sh [options]
        Options:
            -a AMC slot in uTCA crate
            -d Print additional debugging info
            -h Display this message and exit
            -l Latency range given as two numbers separated by a hyphen, e.g. 38-48
            -o ohMask to use for this scan (a 1 in the N^th bit means use the N^th OH)
            -s uTCA crate shelf number
            -t Time to wait in seconds before changing the latency
```

Example call:

```bash
autoLatScan.sh -a 5 -l 25-150 -o 0xA -s 2 -t 60
```

### Example calls of `runLDQM.sh`

Help menu:

```bash
% runLDQM.sh -h

Individually processes chunk files found in /data/bigdisk/GEM-Data-Taking/GE11_QC8//Cosmics (or provided -p argument) with the unpacker, adds the output raw.root files together, and then processes this final file with the light dqm.
        Usage: mergeFiles.sh [options]
        Options:
            -d Outputs commands that will be executed, nothing is produced
            -i initial chunk number to consider, defaults to 0
            -f final chunk number to consider, if not provided all chunk files will be processed
            -h prints this menu and exits
            -p path to datafiles of the form 'runXXXXXX_Cosmic_CERNQC8_YYYY-MM-DD_chunk_*.dat'
            -r run number of interest
```

Example call:
```bash
runLDQM.sh -p /data/bigdisk/GEM-Data-Taking/SustainedOperations -r 27 -i 2 -f 339
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
