### PR TITLE
Use a time-stamped folder for most log files and output data from calibrateArmDac.sh

### DIFF
--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -38,6 +38,7 @@ echo -e "ChamberName\tscandate\tCFG_THR_ARM_DAC" 2>&1 | tee ${DATA_PATH}/${DETEC
 
 scandate=$(date +%Y.%m.%d.%H.%M)
 mkdir -p ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}
+ln -s ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate} ${DATA_PATH}/${DETECTOR}/armDacCal/current
 
 runNum=0
 for armDacVal in $(echo $LIST_ARM_DAC | sed "s/,/ /g")

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -90,8 +90,8 @@ do
 
     echo "Analyzing results"
     echo "Analysis Log for scandate: ${scurve_scandate}" 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
-    echo "anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt"
-    anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
+    echo "anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
+    anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
     echo "granting permissions to ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}"

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -59,14 +59,13 @@ then
     return
 fi
 
-echo -e "ChamberName\tscandate\tCFG_THR_ARM_DAC" 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/listOfScanDates_calibrateArmDac_${DETECTOR}.txt
-
 if [ -z ${RESUMEDIR} ];
 then
     scandate=$(date +%Y.%m.%d.%H.%M)
     OUTDIR=${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}
     mkdir -p $OUTDIR
     ln -snf $OUTDIR ${DATA_PATH}/${DETECTOR}/armDacCal/current
+    echo -e "ChamberName\tscandate\tCFG_THR_ARM_DAC" 2>&1 | tee $OUTDIR/listOfScanDates_calibrateArmDac_${DETECTOR}.txt
 else
     if [ ! -d ${RESUMEDIR} ];
     then
@@ -74,6 +73,10 @@ else
         return;
     fi
     OUTDIR=$RESUMEDIR
+    #when running in resume mode, the list of scan dates file should already exist and we should not write the header again
+    if [ ! -f $OUTDIR/listOfScanDates_calibrateArmDac_${DETECTOR}.txt ]; then
+        echo -e "ChamberName\tscandate\tCFG_THR_ARM_DAC" 2>&1 | tee $OUTDIR/listOfScanDates_calibrateArmDac_${DETECTOR}.txt
+    fi
 fi
 
 runNum=0

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -34,71 +34,76 @@ then
     return
 fi
 
-echo -e "ChamberName\tscandate\tCFG_THR_ARM_DAC" 2>&1 | tee listOfScanDates_calibrateArmDac_${DETECTOR}.txt
+echo -e "ChamberName\tscandate\tCFG_THR_ARM_DAC" 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/listOfScanDates_calibrateArmDac_${DETECTOR}.txt
+
+scandate=$(date +%Y.%m.%d.%H.%M)
 
 runNum=0
 for armDacVal in $(echo $LIST_ARM_DAC | sed "s/,/ /g")
 do
-    if [ -e scurveLog_ArmDac_${armDacVal}.txt ]
+    if [ -e ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt ]
     then
-        rm scurveLog_ArmDac_${armDacVal}.txt
+        rm ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     fi
 
     echo "=============Run $runNum============="
     echo "Issuing a link reset before CFG_THR_ARM_DAC=${armDacVal}"
-    echo "gem_reg.py -n ${CARDNAME} -e write 'GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1' 2>&1 | tee scurveLog_ArmDac_${armDacVal}.txt"
-    gem_reg.py -n ${CARDNAME} -e write "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1" 2>&1 | tee scurveLog_ArmDac_${armDacVal}.txt
+    echo "gem_reg.py -n ${CARDNAME} -e write 'GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1' 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
+    gem_reg.py -n ${CARDNAME} -e write "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1" 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
     echo "Configuring Detector for CFG_THR_ARM_DAC=${armDacVal}"
-    echo "confChamber.py -c ${CARDNAME} -g ${LINK} --vt1=${armDacVal} --vfatmask=${MASK} --zeroChan --run 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt"
-    confChamber.py -c ${CARDNAME} -g ${LINK} --vt1=${armDacVal} --vfatmask=${MASK} --zeroChan --run 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
+    echo "confChamber.py -c ${CARDNAME} -g ${LINK} --vt1=${armDacVal} --vfatmask=${MASK} --zeroChan --run 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
+    confChamber.py -c ${CARDNAME} -g ${LINK} --vt1=${armDacVal} --vfatmask=${MASK} --zeroChan --run 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
     
     echo "Writing configuration for CFG_THR_ARM_DAC=${armDacVal} to file"
-    echo "gem_reg.py -n ${CARDNAME} -e kw 'GEM_AMC.OH.OH${LINK}.GEB.VFAT0.CFG_' 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt"
-    echo "Configuration of All VFATs:" 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
-    gem_reg.py -n ${CARDNAME} -e kw "GEM_AMC.OH.OH${LINK}.GEB.VFAT0.CFG_" 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
+    echo "gem_reg.py -n ${CARDNAME} -e kw 'GEM_AMC.OH.OH${LINK}.GEB.VFAT0.CFG_' 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
+    echo "Configuration of All VFATs:" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
+    gem_reg.py -n ${CARDNAME} -e kw "GEM_AMC.OH.OH${LINK}.GEB.VFAT0.CFG_" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
     echo "Writing IREF configuration for CFG_THR_ARM_DAC=${armDacVal} to file"
-    echo "gem_reg.py -n ${CARDNAME} -e rwc 'GEM_AMC.OH.OH${LINK}.GEB.VFAT*.CFG_IREF' 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt"
-    echo "CFG_IREF of All VFATs:" 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
-    gem_reg.py -n ${CARDNAME} -e rwc "GEM_AMC.OH.OH${LINK}.GEB.VFAT*.CFG_IREF" 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
+    echo "gem_reg.py -n ${CARDNAME} -e rwc 'GEM_AMC.OH.OH${LINK}.GEB.VFAT*.CFG_IREF' 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
+    echo "CFG_IREF of All VFATs:" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
+    gem_reg.py -n ${CARDNAME} -e rwc "GEM_AMC.OH.OH${LINK}.GEB.VFAT*.CFG_IREF" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
-    scandate=$(date +%Y.%m.%d.%H.%M)
-    echo "Making Directory: ${DATA_PATH}/${DETECTOR}/scurve/${scandate}"
-    echo "mkdir -p ${DATA_PATH}/${DETECTOR}/scurve/${scandate}"
-    mkdir -p ${DATA_PATH}/${DETECTOR}/scurve/${scandate}
+    scurve_scandate=$(date +%Y.%m.%d.%H.%M)
+    echo "Making Directory: ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}"
+    echo "mkdir -p ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}"
+    mkdir -p ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}
     echo "unlink ${DATA_PATH}/${DETECTOR}/scurve/current"
     unlink ${DATA_PATH}/${DETECTOR}/scurve/current
-    echo "ln -sf ${DATA_PATH}/${DETECTOR}/scurve/${scandate} ${DATA_PATH}/${DETECTOR}/scurve/current"
-    ln -sf ${DATA_PATH}/${DETECTOR}/scurve/${scandate} ${DATA_PATH}/${DETECTOR}/scurve/current
+    echo "ln -sf ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate} ${DATA_PATH}/${DETECTOR}/scurve/current"
+    ln -sf ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate} ${DATA_PATH}/${DETECTOR}/scurve/current
 
     echo "Adding Entry to listOfScanDates_calibrateArmDac_${DETECTOR}.txt"
-    echo -e "${DETECTOR}\t${scandate}\t${armDacVal}" 2>&1 | tee -a listOfScanDates_calibrateArmDac_${DETECTOR}.txt
+    echo -e "${DETECTOR}\t${scurve_scandate}\t${armDacVal}" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/listOfScanDates_calibrateArmDac_${DETECTOR}.txt
 
     echo "Launching scurve for CFG_THR_ARM_DAC=${armDacVal}"
-    echo "Scurve Output for scandate: ${scandate}" 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
-    echo "ultraScurve.py -c ${CARDNAME} -g ${LINK} --vfatmask=${MASK} --latency=33 --mspl=3 --nevts=100 --voltageStepPulse --filename=${DATA_PATH}/${DETECTOR}/scurve/${scandate}/SCurveData.root 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt"
-    ultraScurve.py -c ${CARDNAME} -g ${LINK} --vfatmask=${MASK} --latency=33 --mspl=3 --nevts=100 --voltageStepPulse --filename=${DATA_PATH}/${DETECTOR}/scurve/${scandate}/SCurveData.root 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
+    echo "Scurve Output for scandate: ${scurve_scandate}" 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
+    echo "ultraScurve.py -c ${CARDNAME} -g ${LINK} --vfatmask=${MASK} --latency=33 --mspl=3 --nevts=100 --voltageStepPulse --filename=${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
+    ultraScurve.py -c ${CARDNAME} -g ${LINK} --vfatmask=${MASK} --latency=33 --mspl=3 --nevts=100 --voltageStepPulse --filename=${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
     echo "Analyzing results"
-    echo "Analysis Log for scandate: ${scandate}" 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
-    echo "anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt"
-    anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
+    echo "Analysis Log for scandate: ${scurve_scandate}" 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
+    echo "anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt"
+    anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
-    echo "granting permissions to ${DATA_PATH}/${DETECTOR}/scurve/${scandate}"
-    echo "chmod g+rw -R ${DATA_PATH}/${DETECTOR}/scurve/${scandate}"
-    chmod g+rw -R ${DATA_PATH}/${DETECTOR}/scurve/${scandate}
+    echo "granting permissions to ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}"
+    echo "chmod g+rw -R ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}"
+    chmod g+rw -R ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}
 
     runNum=$(($runNum + 1))
 done
 
-echo "calibrateThrDac.py listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee armDacCalLog_${DETECTOR}.txt"
-calibrateThrDac.py listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee armDacCalLog_${DETECTOR}.txt
+echo "calibrateThrDac.py listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/armDacCalLog_${DETECTOR}.txt"
+
+export ELOG_PATH = ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/
+
+calibrateThrDac.py listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/armDacCalLog_${DETECTOR}.txt
 
 echo "Finished running all scans"

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -59,7 +59,7 @@ do
     i=0; for vfat in $mask_as_array; do echo $vfat; if [ $vfat == 0 ]; then first_unmasked_vfat=$i; break; fi; i=$(($i+1)) done;
     
     echo "Writing configuration for CFG_THR_ARM_DAC=${armDacVal} to file"
-    echo "gem_reg.py -n ${CARDNAME} -e kw 'GEM_AMC.OH.OH${LINK}.GEB.VFAT0.CFG_' 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
+    echo "gem_reg.py -n ${CARDNAME} -e kw 'GEM_AMC.OH.OH${LINK}.GEB.VFAT${first_unmasked_vfat}.CFG_' 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
     echo "Configuration of All VFATs:" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     gem_reg.py -n ${CARDNAME} -e kw "GEM_AMC.OH.OH${LINK}.GEB.VFAT${first_unmasked_vfat}.CFG_" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -84,6 +84,7 @@ then
     scandate=$(date +%Y.%m.%d.%H.%M)
     OUTDIR=${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}
     mkdir -p $OUTDIR
+    chmod g+rw $OUTDIR
     ln -snf $OUTDIR ${DATA_PATH}/${DETECTOR}/armDacCal/current
     echo -e "ChamberName\tscandate\tCFG_THR_ARM_DAC" 2>&1 | tee $OUTDIR/listOfScanDates_calibrateArmDac_${DETECTOR}.txt
 else

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -38,6 +38,7 @@ echo -e "ChamberName\tscandate\tCFG_THR_ARM_DAC" 2>&1 | tee ${DATA_PATH}/${DETEC
 
 scandate=$(date +%Y.%m.%d.%H.%M)
 mkdir -p ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}
+unlink ${DATA_PATH}/${DETECTOR}/armDacCal/current
 ln -sf ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate} ${DATA_PATH}/${DETECTOR}/armDacCal/current
 
 runNum=0
@@ -56,7 +57,7 @@ do
 
     first_unmasked_vfat=0
     mask_as_array=`echo "obase=2; ibase=16; \`echo $MASK | awk -F"0x" '{print $2}' | awk '{print toupper($1)}'\`;" | bc | grep -o .`
-    i=0; for vfat in $mask_as_array; do echo $vfat; if [ $vfat == 0 ]; then first_unmasked_vfat=$i; break; fi; i=$(($i+1)) done;
+    i=0; for vfat in $mask_as_array; do echo $vfat; if [ $vfat == 0 ]; then first_unmasked_vfat=$i; break; fi; i=$(($i+1)); done;
     
     echo "Writing configuration for CFG_THR_ARM_DAC=${armDacVal} to file"
     echo "gem_reg.py -n ${CARDNAME} -e kw 'GEM_AMC.OH.OH${LINK}.GEB.VFAT${first_unmasked_vfat}.CFG_' 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
@@ -83,13 +84,13 @@ do
     echo -e "${DETECTOR}\t${scurve_scandate}\t${armDacVal}" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/listOfScanDates_calibrateArmDac_${DETECTOR}.txt
 
     echo "Launching scurve for CFG_THR_ARM_DAC=${armDacVal}"
-    echo "Scurve Output for scandate: ${scurve_scandate}" 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
+    echo "Scurve Output for scandate: ${scurve_scandate}" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     echo "ultraScurve.py -c ${CARDNAME} -g ${LINK} --vfatmask=${MASK} --latency=33 --mspl=3 --nevts=100 --voltageStepPulse --filename=${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
     ultraScurve.py -c ${CARDNAME} -g ${LINK} --vfatmask=${MASK} --latency=33 --mspl=3 --nevts=100 --voltageStepPulse --filename=${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
     echo "Analyzing results"
-    echo "Analysis Log for scandate: ${scurve_scandate}" 2>&1 | tee -a scurveLog_ArmDac_${armDacVal}.txt
+    echo "Analysis Log for scandate: ${scurve_scandate}" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     echo "anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
     anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -98,10 +98,28 @@ do
     confChamber.py --shelf ${SHELF} -s ${SLOT} -g ${LINK} --vt1=${armDacVal} --vfatmask=${MASK} --zeroChan --run 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
-    first_unmasked_vfat=0
+    echo "Finding the first unmasked VFAT"
+    first_unmasked_vfat=-1
     mask_as_array=`echo "obase=2; ibase=16; \`echo $MASK | awk -F"0x" '{print $2}' | awk '{print toupper($1)}'\`;" | bc | grep -o .`
-    i=0; for vfat in $mask_as_array; do echo $vfat; if [ $vfat == 0 ]; then first_unmasked_vfat=$i; break; fi; i=$(($i+1)); done;
-
+    i=0;
+    for vfat in $mask_as_array;
+    do
+        echo "Checking VFAT ${vfat}";
+        if [ $vfat == 0 ];
+        then
+            first_unmasked_vfat=$i;
+            print "The first unmasked VFAT is VFAT ${vfat}"
+            break;
+        fi;
+        i=$(($i+1));
+    done;
+    
+    if (( $first_unmasked_vfat < 0 || $first_unmasked_vfat > 23 ))
+    then
+        print "Problem finding the first unmasked VFAT, exiting"
+        kill -INT $$
+    fi
+    
     echo "Writing configuration for CFG_THR_ARM_DAC=${armDacVal} to file"
     echo "gem_reg.py -n ${CARDNAME} -e kw 'GEM_AMC.OH.OH${LINK}.GEB.VFAT${first_unmasked_vfat}.CFG_' 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt"
     echo "Configuration of All VFATs:" 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -37,6 +37,7 @@ fi
 echo -e "ChamberName\tscandate\tCFG_THR_ARM_DAC" 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/listOfScanDates_calibrateArmDac_${DETECTOR}.txt
 
 scandate=$(date +%Y.%m.%d.%H.%M)
+mkdir -p ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}
 
 runNum=0
 for armDacVal in $(echo $LIST_ARM_DAC | sed "s/,/ /g")
@@ -107,3 +108,5 @@ export ELOG_PATH = ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/
 calibrateThrDac.py listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/armDacCalLog_${DETECTOR}.txt
 
 echo "Finished running all scans"
+
+chmod g+rw -R ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -140,7 +140,7 @@ do
         if [ $vfat == 0 ];
         then
             first_unmasked_vfat=$i;
-            print "The first unmasked VFAT is VFAT ${vfat}"
+            echo "The first unmasked VFAT is VFAT ${vfat}"
             break;
         fi;
         i=$(($i+1));
@@ -148,7 +148,7 @@ do
     
     if (( $first_unmasked_vfat < 0 || $first_unmasked_vfat > 23 ))
     then
-        print "Problem finding the first unmasked VFAT, exiting"
+        echo "Problem finding the first unmasked VFAT, exiting"
         kill -INT $$
     fi
     

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 usage() {
-    echo './calibrateArmDac.sh -s slot -l link  -L armdaclist [-D detName] [-S shelf] [-m vfatmask] [-r path]'
+    echo './calibrateArmDac.sh -s slot -l link  -L armdaclist [-d detName] [-S shelf] [-m vfatmask] [-r path]'
     echo ''
     echo '    slot: Slot number'
     echo '    link: OH number on the CTP7'

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -4,6 +4,7 @@
 
 helpstring="Usage:
     ./executeScurveProgram.sh [DetName] [cardName] [link] [vfatmask] [comma separated list of CFG_THR_ARM_DAC Values]
+    ./executeScurveProgram.sh -r [PATH] [DetName] [cardName] [link] [vfatmask] [comma separated list of CFG_THR_ARM_DAC Values]
         
     For each CFG_THR_ARM_DAC value specified will create a scandate directory, configure, print the configuration, and take an scurve
 
@@ -11,7 +12,27 @@ helpstring="Usage:
         cardName: CTP7 network alias or ip address
         link: OH number on the CTP7
         vfatmask: 24-bit mask where a 1 in the n^th bit implies the n^th VFAT shall be excluded
+
+    If -r [PATH] is provided, the directory [PATH] will be used instead of creating a new scandate directory and ARM DAC values for which a scurve log file already exists in that directory will be skipped
 "
+
+ISFILE=0;
+OPTIND=1
+while getopts "f:h" opts
+do
+    case $opts in
+        r)
+            RESUMEDIR=$OPTARG;;
+        h)
+            echo ${helpstring};;
+        \?)
+            echo ${helpstring};;
+        [?])
+            echo ${helpstring};;
+    esac
+done
+shift $((OPTIND-1))
+unset OPTIND
 
 DETECTOR=$1
 CARDNAME=$2
@@ -36,23 +57,39 @@ fi
 
 echo -e "ChamberName\tscandate\tCFG_THR_ARM_DAC" 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/listOfScanDates_calibrateArmDac_${DETECTOR}.txt
 
-scandate=$(date +%Y.%m.%d.%H.%M)
-mkdir -p ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}
-unlink ${DATA_PATH}/${DETECTOR}/armDacCal/current
-ln -sf ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate} ${DATA_PATH}/${DETECTOR}/armDacCal/current
+if [ -z ${RESUMEDIR} ];
+then
+    if [ ! -d ${RESUMEDIR} ];
+    then
+        echo "Error: provided directory ${RESUMEDIR} does not exist or is not a directory."
+        return;
+    fi
+    OUTDIR=$RESUMEDIR
+else
+    scandate=$(date +%Y.%m.%d.%H.%M)
+    OUTDIR=${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}
+    mkdir -p $OUTDIR
+    unlink $OUTDIR
+    ln -sf $OUTDIR ${DATA_PATH}/${DETECTOR}/armDacCal/current
+fi
 
 runNum=0
 for armDacVal in $(echo $LIST_ARM_DAC | sed "s/,/ /g")
 do
+
+    if [ -f $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt ]; then
+        continue;
+    fi
+
     echo "=============Run $runNum============="
     echo "Issuing a link reset before CFG_THR_ARM_DAC=${armDacVal}"
-    echo "gem_reg.py -n ${CARDNAME} -e write 'GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1' 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
-    gem_reg.py -n ${CARDNAME} -e write "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1" 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
+    echo "gem_reg.py -n ${CARDNAME} -e write 'GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1' 2>&1 | tee $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt"
+    gem_reg.py -n ${CARDNAME} -e write "GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET 1" 2>&1 | tee $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
     echo "Configuring Detector for CFG_THR_ARM_DAC=${armDacVal}"
-    echo "confChamber.py -c ${CARDNAME} -g ${LINK} --vt1=${armDacVal} --vfatmask=${MASK} --zeroChan --run 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
-    confChamber.py -c ${CARDNAME} -g ${LINK} --vt1=${armDacVal} --vfatmask=${MASK} --zeroChan --run 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
+    echo "confChamber.py -c ${CARDNAME} -g ${LINK} --vt1=${armDacVal} --vfatmask=${MASK} --zeroChan --run 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt"
+    confChamber.py -c ${CARDNAME} -g ${LINK} --vt1=${armDacVal} --vfatmask=${MASK} --zeroChan --run 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
     first_unmasked_vfat=0
@@ -60,15 +97,15 @@ do
     i=0; for vfat in $mask_as_array; do echo $vfat; if [ $vfat == 0 ]; then first_unmasked_vfat=$i; break; fi; i=$(($i+1)); done;
     
     echo "Writing configuration for CFG_THR_ARM_DAC=${armDacVal} to file"
-    echo "gem_reg.py -n ${CARDNAME} -e kw 'GEM_AMC.OH.OH${LINK}.GEB.VFAT${first_unmasked_vfat}.CFG_' 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
-    echo "Configuration of All VFATs:" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
-    gem_reg.py -n ${CARDNAME} -e kw "GEM_AMC.OH.OH${LINK}.GEB.VFAT${first_unmasked_vfat}.CFG_" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
+    echo "gem_reg.py -n ${CARDNAME} -e kw 'GEM_AMC.OH.OH${LINK}.GEB.VFAT${first_unmasked_vfat}.CFG_' 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt"
+    echo "Configuration of All VFATs:" 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt
+    gem_reg.py -n ${CARDNAME} -e kw "GEM_AMC.OH.OH${LINK}.GEB.VFAT${first_unmasked_vfat}.CFG_" 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
     echo "Writing IREF configuration for CFG_THR_ARM_DAC=${armDacVal} to file"
-    echo "gem_reg.py -n ${CARDNAME} -e rwc 'GEM_AMC.OH.OH${LINK}.GEB.VFAT*.CFG_IREF' 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
-    echo "CFG_IREF of All VFATs:" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
-    gem_reg.py -n ${CARDNAME} -e rwc "GEM_AMC.OH.OH${LINK}.GEB.VFAT*.CFG_IREF" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
+    echo "gem_reg.py -n ${CARDNAME} -e rwc 'GEM_AMC.OH.OH${LINK}.GEB.VFAT*.CFG_IREF' 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt"
+    echo "CFG_IREF of All VFATs:" 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt
+    gem_reg.py -n ${CARDNAME} -e rwc "GEM_AMC.OH.OH${LINK}.GEB.VFAT*.CFG_IREF" 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
     scurve_scandate=$(date +%Y.%m.%d.%H.%M)
@@ -81,18 +118,18 @@ do
     ln -sf ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate} ${DATA_PATH}/${DETECTOR}/scurve/current
 
     echo "Adding Entry to listOfScanDates_calibrateArmDac_${DETECTOR}.txt"
-    echo -e "${DETECTOR}\t${scurve_scandate}\t${armDacVal}" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/listOfScanDates_calibrateArmDac_${DETECTOR}.txt
+    echo -e "${DETECTOR}\t${scurve_scandate}\t${armDacVal}" 2>&1 | tee -a $OUTDIR/listOfScanDates_calibrateArmDac_${DETECTOR}.txt
 
     echo "Launching scurve for CFG_THR_ARM_DAC=${armDacVal}"
-    echo "Scurve Output for scandate: ${scurve_scandate}" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
-    echo "ultraScurve.py -c ${CARDNAME} -g ${LINK} --vfatmask=${MASK} --latency=33 --mspl=3 --nevts=100 --voltageStepPulse --filename=${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
-    ultraScurve.py -c ${CARDNAME} -g ${LINK} --vfatmask=${MASK} --latency=33 --mspl=3 --nevts=100 --voltageStepPulse --filename=${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
+    echo "Scurve Output for scandate: ${scurve_scandate}" 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt
+    echo "ultraScurve.py -c ${CARDNAME} -g ${LINK} --vfatmask=${MASK} --latency=33 --mspl=3 --nevts=100 --voltageStepPulse --filename=${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt"
+    ultraScurve.py -c ${CARDNAME} -g ${LINK} --vfatmask=${MASK} --latency=33 --mspl=3 --nevts=100 --voltageStepPulse --filename=${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
     echo "Analyzing results"
-    echo "Analysis Log for scandate: ${scurve_scandate}" 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
-    echo "anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt"
-    anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/scurveLog_ArmDac_${armDacVal}.txt
+    echo "Analysis Log for scandate: ${scurve_scandate}" 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt
+    echo "anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt"
+    anaUltraScurve.py -i ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}/SCurveData.root -c --calFile=${DATA_PATH}/${DETECTOR}/calFile_calDac_${DETECTOR}.txt -f --isVFAT3 --deadChanCutLow=0 --deadChanCutHigh=0 --highNoiseCut=20 --maxEffPedPercent=0.1 2>&1 | tee -a $OUTDIR/scurveLog_ArmDac_${armDacVal}.txt
     sleep 1
 
     echo "granting permissions to ${DATA_PATH}/${DETECTOR}/scurve/${scurve_scandate}"
@@ -102,12 +139,12 @@ do
     runNum=$(($runNum + 1))
 done
 
-echo "calibrateThrDac.py listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/armDacCalLog_${DETECTOR}.txt"
+echo "calibrateThrDac.py listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee $OUTDIR/armDacCalLog_${DETECTOR}.txt"
 
-export ELOG_PATH = ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/
+export ELOG_PATH = $OUTDIR/
 
-calibrateThrDac.py listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}/armDacCalLog_${DETECTOR}.txt
+calibrateThrDac.py listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee $OUTDIR/armDacCalLog_${DETECTOR}.txt
 
 echo "Finished running all scans"
 
-chmod g+rw -R ${DATA_PATH}/${DETECTOR}/armDacCal/${scandate}
+chmod g+rw -R $OUTDIR

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -142,11 +142,16 @@ do
     runNum=$(($runNum + 1))
 done
 
-echo "calibrateThrDac.py listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee $OUTDIR/armDacCalLog_${DETECTOR}.txt"
-
 export ELOG_PATH=$OUTDIR/
 
-calibrateThrDac.py listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee $OUTDIR/armDacCalLog_${DETECTOR}.txt
+#in a venv, the scripts in the macros directory of gem-plotting-tools, including calibrateThrDac.py, are not set as executable when they are installed
+if [ $VIRTUAL_ENV ]
+   then
+       chmod a+x `find $VIRTUAL_ENV -name calibrateThrDac.py`;
+fi
+
+echo "calibrateThrDac.py $OUTDIR/listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee $OUTDIR/armDacCalLog_${DETECTOR}.txt"
+calibrateThrDac.py $OUTDIR/listOfScanDates_calibrateArmDac_${DETECTOR}.txt 2>&1 | tee $OUTDIR/armDacCalLog_${DETECTOR}.txt
 
 echo "Finished running all scans"
 

--- a/scripts/calibrateArmDac.sh
+++ b/scripts/calibrateArmDac.sh
@@ -71,7 +71,7 @@ then
     MASK=`python -c "from gempython.tools.amc_user_functions_xhal import HwAMC; amcboard = HwAMC('${CARDNAME}'); print str(hex(amcboard.getLinkVFATMask(${LINK}))).strip('L')" | tail -n 1`
 fi
 
-xport DATA_PATH=/<your>/<data>/<directory>
+#export DATA_PATH=/<your>/<data>/<directory>
 if [ -z "$DATA_PATH" ]
 then
     echo "DATA_PATH not set, please set DATA_PATH to a directory where data files created by scan applications will be written"


### PR DESCRIPTION
Currently, most of the output and logging go to the working directory. This pull request makes it go to a dedicated time-stamped folder instead.

## Description

1) Creates a new directory $DATA_PATH/$DETECTOR/armDacCal/scandate/
2) Creates a soft link `current` to that directory
3) Places all of the scurve and calibrateThrDac.py log files in $DATA_PATH/$DETECTOR/armDacCal/scandate/
4) Places the listOfScanDates file in $DATA_PATH/$DETECTOR/armDacCal/scandate/
5) Sets ELOG_PATH to $DATA_PATH/$DETECTOR/armDacCal/scandate/ before running calibrateThrDac.py, causing calibrateThrDac.py to place all of its output

The scurve output location is not changed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This was requested in https://github.com/cms-gem-daq-project/sw_utils/issues/18

## How Has This Been Tested?
It has not been tested.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
