### PR TITLE
New Feature: user can now provide geographic address

### DIFF
--- a/scripts/doQC7.sh
+++ b/scripts/doQC7.sh
@@ -2,21 +2,29 @@
 
 helpstring="Usage: doQC7.sh -c [DetName]
     Options:
+        -a AMC slot number inside uTCA shelf
         -c chamber name, without '/' characters, e.g. 'GE11-X-S-CERN-0007'
+        -d Debugging flag, prints additional information
         -f starting step to begin testConnectivity.py with, defaults to 1, options [1,5]
-        -d Debugging flag, prints additional information"
+        -s uTCA shelf number"
 
+AMCSLOT="5"
 CHAMBER_NAME=""
+SHELF="2"
 STARTINGSTEP="1"
 
 OPTIND=1
-while getopts "c:f:h" opts
+while getopts "a:c:f:s:hd" opts
 do
     case $opts in
+        a)
+            AMCSLOT="$OPTARG";;
         c)
             CHAMBER_NAME="$OPTARG";;
         f)
             STARTINGSTEP="$OPTARG";;
+        s)
+            SHELF="$OPTARG";;
         h)
             echo >&2 "${helpstring}"
             kill -INT $$;;
@@ -71,8 +79,8 @@ echo "Terminal output will be saved too: ${LOGFILE}"
 echo "Calling Command: " 2>&1 | tee ${LOGFILE}
 
 # Call testConnectivity.py
-echo "testConnectivity.py -c ${CHAMBER_NAME} --checkCSCTrigLink -f${STARTINGSTEP} -n 200 -o 0x10 --shelf=2 -s5 --writePhases2File" 2>&1 | tee -a ${LOGFILE}
-testConnectivity.py -c ${CHAMBER_NAME} --checkCSCTrigLink -f${STARTINGSTEP} -n 200 -o 0x10 --shelf=2 -s5 --writePhases2File 2>&1 | tee -a ${LOGFILE}
+echo "testConnectivity.py -c ${CHAMBER_NAME} --checkCSCTrigLink -f${STARTINGSTEP} -n 50 -o 0x10 --shelf=${SHELF} -s${AMCSLOT} --writePhases2File" 2>&1 | tee -a ${LOGFILE}
+testConnectivity.py -c ${CHAMBER_NAME} --checkCSCTrigLink -f${STARTINGSTEP} -n 50 -o 0x10 --shelf=${SHELF} -s${AMCSLOT} --writePhases2File 2>&1 | tee -a ${LOGFILE}
 
 # Move the GBT phase scan log to ${DATA_PATH}/${CHAMBER_NAME}
 phaseScanLog=${ELOG_PATH}/gbtPhaseSettings.log


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For QC7 script the user can now provide the geographic address via the `-s` and `-a` arguments for respectively shelf and AMC slot.  These default to `shelf=2` and `slot=5` if not provided.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
There are now two setups for QC7 and so the user needs to be able to specify which setup they are using.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change was trivial.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
