### PR TITLE
Utility for quickly updating chConfig & vfatConfig files under DATA_PATH/configs

### DIFF
--- a/profiles/gem904qc8daq/.aliases
+++ b/profiles/gem904qc8daq/.aliases
@@ -3,9 +3,8 @@ alias ll='ls -lhtr'
 alias rm='mv -t "$@" ~/.Trash'
 
 # GEM DAQ function calls
-#alias AMC13Tool2.ext='/opt/cactus/bin/amc13/AMC13Tool2.exe -i gem.shelf01.amc13 -c $GEM_ADDRESS_TABLE_PATH/connections.xml'
 alias gbtProgrammer='java -jar /data/bigdisk/sw/GBTx_programmer/programmerv2.20180116.jar'
-alias editConfig='vim /usr/lib/python2.7/site-packages/gempython/gemplotting/mapping/chamberInfo.py'
+alias editConfig='vim /home/gemuser/gemdaq/config/system_specific_constants.py'
 alias calibrateArmDac.sh='. /home/gemuser/gemdaq/sw_utils/scripts/calibrateArmDac.sh'
 
 # ROOT calls

--- a/profiles/gem904qc8daq/.bash_profile
+++ b/profiles/gem904qc8daq/.bash_profile
@@ -8,6 +8,9 @@ fi
 # User specific environment and startup programs
 export LC_ALL="en_US.UTF-8"
 
+# Set umask for group read and write
+umask g+rw
+
 ##################  Colors ##########################
 BLUE='\033[0;34m'
 GREEN='\033[0;32m'
@@ -30,10 +33,6 @@ else
 fi
 
 # setup gemdaq
-#export PATH=/opt/cmsgemos/bin:$PATH
-#export GEM_ADDRESS_TABLE_PATH=/opt/cmsgemos/etc/maps
-#export GEM_ADDRESS_TABLE_PATH=/home/gemuser/gemdaq/cmsgemos/setup/etc/addresstables
-
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/wiscrpcsvc/lib/
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/xhal/lib/
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rwreg/lib/
@@ -54,7 +53,6 @@ export GEM_DB_PORT=3306
 
 # GEM Online DB Locations
 export GEM_ONLINE_DB_NAME="enter db name"
-#export GEM_ONLINE_DB_NAME="enter db name"
 export GEM_ONLINE_DB_CONN="enter db connection"
 
 # Add config tools to path
@@ -70,23 +68,30 @@ export PATH=$BUILD_HOME/gem-light-dqm/dqm-root/bin/linux/x86_64_centos7/:$PATH
 # Add sw_utils to path
 export PATH=$BUILD_HOME/sw_utils/scripts/:$PATH
 
+# Add gem_ops scripts
+export PATH=$BUILD_HOME/gem_ops/DCS_STATUS:$PATH
+
+# Add system specific hardware constants to PYTHONPATH
+export PYTHONPATH=/home/gemuser/gemdaq/config:$PYTHONPATH
+
 ################## USER MESSAGES ####################
 
-echo -e ""                                                                                                                                                                                                                        
+echo -e ""
+echo "Current umask is:"
+umask -S
+echo ""
 echo -e "If the system experienced a power cut to recover follow instructions:"
 echo -e "  ${BLUE}https://github.com/cms-gem-daq-project/sw_utils/blob/develop/v3ElectronicsUserGuide.md#recovering-from-a-power-cut${NOCOL}"
 echo -e "An example of a successful CTP7 recovery is shown:"
 echo -e "  ${BLUE}http://cmsonline.cern.ch/cms-elog/1060543${NOCOL}"
 echo -e ""
-
-echo ""
 echo 'Firmware files can be found under $FIRMWARE_GEM'
 echo '   $FIRMWARE_GEM/OptoHybrid'
 echo '   $FIRMWARE_GEM/CTP7'
 echo ""
-
+echo 'GBT Settings can be found under $GBT_SETTINGS/OHv3c'
 echo ""
-echo "To connect to the AMC13 for eagle26 & eagle35 execute:"
+echo "To connect to the AMC13 for eagle23, eagle26 & eagle35 execute:"
 echo -e ${GREEN}
 echo '  AMC13Tool2.exe -i gem.shelf01.amc13 -c $GEM_ADDRESS_TABLE_PATH/connections.xml'
 echo -e ${NOCOL}
@@ -96,12 +101,8 @@ echo -e ${GREEN}
 echo '  AMC13Tool2.exe -i gem.shelf02.amc13 -c $GEM_ADDRESS_TABLE_PATH/connections.xml'
 echo -e ${NOCOL}
 echo ""
-
-echo ""
 echo "To launch the command line register interface with the CTP7 execute:"
 echo -e "  ${GREEN}gem_reg.py${NOCOL}"
-echo ""
-
 echo ""
 echo "To change the configuration that will be written when calling confChamber.py"
 echo "edit the chamber_vfatDACSettings dictionary for the corresponding link by calling:"
@@ -109,7 +110,6 @@ echo "edit the chamber_vfatDACSettings dictionary for the corresponding link by 
 echo -e "   ${GREEN}editConfig${NOCOL}"
 echo ""
 echo "Note: editing other dictionaries in this file may lead to undefined behavior."
-
 echo ""
 echo -e "The available screen's are: ${GREEN}"
 screen -list
@@ -118,8 +118,6 @@ echo -e "To dettach from a screen press ${BLUE}'Ctrl+A' then 'D'${NOCOL}"
 echo -e "To scroll inside a screen press ${BLUE}'Ctrl+A' then 'Esc'${NOCOL}"
 echo -e "To stop scrolling inside a scree press ${BLUE}'Esc'${NOCOL}"
 echo -e "To attach to a screen execute: ${BLUE}screen -r -S SCREENNAME${NOCOL}"
-echo ""
-
 echo ""
 echo -e "The RCMS server for 904 is accessible at:"
 echo -e "   ${BLUE}http://gem904daq01:10000/rcms/gui/servlet/FMPilotServlet${NOCOL}"

--- a/python/updateConf.py
+++ b/python/updateConf.py
@@ -1,0 +1,110 @@
+#!/bin/env python
+
+r"""
+updateNewConf.py
+==========
+
+.. moduleauthor:: Brian Dorney <brian.l.dorney@cern.ch>
+"""
+
+from gempython.utils.gemlogger import printYellow, printRed
+
+def getChConfigFileDict(chamber_config, scandate, debug=False, takeFromSCurve=True):
+    """
+    Returns a dictionary of chConfig files.
+
+    chamber_config  - Dictionary whose key values are geographic address, e.g. (shelf,slot,link), and values are detector serial numbers
+    scandate        - Either None or a string specifying the scandate of the files of interest, in YYYY.MM.DD.hh.mm format
+    debug           - Prints debugging information if True
+    """
+    fileDict = {}
+
+    from gempython.gemplotting.utils.anaInfo import tree_names
+    from gempython.gemplotting.utils.anautilities import getDirByAnaType
+    import os
+    listOfFoundFiles = [ ]
+    for geoAddr,cName in chamber_config.iteritems():
+        if takeFromSCurve:
+            filename = "{}/{}/SCurveData/chConfig.txt".format(getDirByAnaType("scurve",cName),scandate)
+        else:
+            filename = "{}/{}/ThresholdScanData/chConfig_MasksUpdated.txt".format(getDirByAnaType("thresholdch",cName),scandate)
+
+        # Check that this file is not in listOfFoundFiles
+        if ((filename not in listOfFoundFiles) and os.path.isfile(filename)):
+            fileDict[cName]=filename
+            listOfFoundFiles.append(filename)
+        else:
+            if debug:
+                printYellow("filename not found: {}".format(filename))
+        pass
+
+    return fileDict
+
+def getVFATConfigFileDict(chamber_config, scandate, debug=False):
+    """
+    Returns a dictionary of vfatConfig files.
+
+    chamber_config  - Dictionary whose key values are geographic address, e.g. (shelf,slot,link), and values are detector serial numbers
+    scandate        - Either None or a string specifying the scandate of the files of interest, in YYYY.MM.DD.hh.mm format
+    debug           - Prints debugging information if True
+    """
+    fileDict = {}
+
+    from gempython.gemplotting.utils.anaInfo import tree_names
+    from gempython.gemplotting.utils.anautilities import getDirByAnaType
+    import os
+    listOfFoundFiles = [ ]
+    for geoAddr,cName in chamber_config.iteritems():
+        filename = "{}/{}/vfatConfig.txt".format(getDirByAnaType("sbitRateor",cName),scandate)
+
+        # Check that this file is not in listOfFoundFiles
+        if ((filename not in listOfFoundFiles) and os.path.isfile(filename)):
+            fileDict[cName]=filename
+            listOfFoundFiles.append(filename)
+        else:
+            if debug:
+                printYellow("filename not found: {}".format(filename))
+        pass
+
+    return fileDict
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description="Arguments to supply to updateConf.py")
+
+    parser.add_argument("-d","--debug",action="store_true",help="prints additional debugging information")
+    parser.add_argument("-c","--chConfigScandate",type=str,help="Scandate in YYYY.MM.DD.hh.mm format, or the string 'current', for the scurve measurement to take chConfig from for all detectors",default=None)
+    parser.add_argument("--updatedChConfig",action="store_true",help="The 'chConfigScandate' argument is understood to come from an updated chConfig produced with joint analysis of scurve and tracking data threshold scan measurements; here the scandate is understood as the date of the tracking data threshold scan")
+    parser.add_argument("-v","--vfatConfigScandate",type=str,help="Scandate in YYYY.MM.DD.hh.mm format, or the string 'current', for SBIT Threshold measurement to take vfatConfig from for all detectors",default=None)
+    args = parser.parse_args()
+
+    from gempython.gemplotting.utils.anautilities import getDataPath
+    dataPath = getDataPath()
+
+    import logging
+    from gempython.utils.gemlogger import getGEMLogger
+    gemlogger = getGEMLogger(__name__)
+    gemlogger.setLevel(logging.ERROR)
+
+    import os,sys
+    from gempython.gemplotting.mapping.chamberInfo import chamber_config
+    from gempython.utils.wrappers import runCommand
+    if args.chConfigScandate is None and args.vfatConfigScandate is None:
+        printRed("No scandates provided for either chConfig or vfatConfig. Nothing to do, exiting")
+        sys.exit(os.EX_USAGE)
+    if args.chConfigScandate is not None:
+        chConfigDict = getChConfigFileDict(chamber_config, args.chConfigScandate, args.debug, not args.updatedChConfig)
+        for cName,chConfig in chConfigDict.iteritems():
+            cmd = ["ln","-sf",chConfig,"{}/configs/chConfig_{}.txt".format(dataPath,cName)]
+            runCommand(cmd)
+            pass
+        pass
+    if args.vfatConfigScandate is not None:
+        vfatConfigDict = getVFATConfigFileDict(chamber_config, args.vfatConfigScandate, args.debug)
+        for cName,vfatConfig in vfatConfigDict.iteritems():
+            cmd = ["ln","-sf",vfatConfig,"{}/configs/vfatConfig_{}.txt".format(dataPath,cName)]
+            runCommand(cmd)
+            pass
+        pass
+
+    print("All config links updated, please cross-check via:\n\tll $DATA_PATH/configs")

--- a/scripts/enableLEMO.sh
+++ b/scripts/enableLEMO.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+SHELF=$1
+
+# Check inputs
+if [ -z ${1+x} ] 
+then
+    echo "You must supply a uTCA shelf number, e.g. 'dumpAMC13.sh 1'"
+    kill -INT $$
+fi
+
+echo Enabling LEMO input on gem.shelf0${SHELF}.amc13
+
+echo -e 'wv CONF.TTC.T3_TRIG 1
+exit' | \
+    AMC13Tool2.exe -i gem.shelf0${SHELF}.amc13 -c $GEM_ADDRESS_TABLE_PATH/connections.xml 
+
+echo -e "\nDone, T3_TRIG is now"
+echo -e 'rv CONF.TTC.T3_TRIG
+exit' | \
+    AMC13Tool2.exe -i gem.shelf0${SHELF}.amc13 -c $GEM_ADDRESS_TABLE_PATH/connections.xml 

--- a/scripts/getTrigCount.sh
+++ b/scripts/getTrigCount.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+SHELF=$1
+
+# Check inputs
+if [ -z ${1+x} ] 
+then
+    echo "You must supply a uTCA shelf number, e.g. 'dumpAMC13.sh 1'"
+    kill -INT $$
+fi
+
+ORIG_DIR=$PWD
+echo -e 'st
+exit' | \
+    AMC13Tool2.exe -i gem.shelf0${SHELF}.amc13 -c $GEM_ADDRESS_TABLE_PATH/connections.xml \
+    | grep "L1A"

--- a/scripts/setup_gemdaq.sh
+++ b/scripts/setup_gemdaq.sh
@@ -323,6 +323,7 @@ then
     export LD_LIBRARY_PATH=/opt/wiscrpcsvc/lib:$LD_LIBRARY_PATH
     export LD_LIBRARY_PATH=/opt/xdaq/lib:$LD_LIBRARY_PATH
     export LD_LIBRARY_PATH=/opt/xhal/lib:$LD_LIBRARY_PATH
+    #export LD_LIBRARY_PATH=${BUILD_HOME}/xhal/xhalcore/lib:$LD_LIBRARY_PATH
 
     # Add hardware access tools to PATH
     export PATH=/opt/cactus/bin/amc13/:$PATH
@@ -342,7 +343,7 @@ then
     # Misc
     #alias arp-scan='sudo /usr/sbin/arp-scan'
     alias arp-scan='ip n show dev "$@" to 192.168.0.0/16'
-    alias editConfig='vim $VIRTUAL_ENV/lib/python2.7/site-packages/gempython/gemplotting/mapping/chamberInfo.py'
+    alias editConfig='vim ${BUILD_HOME}/system_specific_constants.py'
     alias gbtProgrammer='java -jar /data/bigdisk/sw/GBTx_programmer/programmerv2.20180116.jar'
 
     # fedKit on gem904daq04

--- a/scripts/setup_gemdaq.sh
+++ b/scripts/setup_gemdaq.sh
@@ -373,6 +373,7 @@ fi
 # Setup path
 export PATH=$VENV_DIR/lib/python$PYTHON_VERSION/site-packages/gempython/scripts:$PATH
 export PATH=$VENV_DIR/lib/python$PYTHON_VERSION/site-packages/gempython/gemplotting/macros:$PATH
+export PATH=$BUILD_HOME/sw_utils/python:$PATH
 export PATH=$BUILD_HOME/sw_utils/scripts:$PATH
 
 # Setup PYTHONPATH


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provides a tool for quickly changing `vfatConfig.txt` and `chConfig.txt` files under `$DATA_PATH/configs`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Doing this by hand for many detectors is not convenient...

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On QC8 system:

```
% updateConf.py -h
usage: updateConf.py [-h] [-d] [-c CHCONFIGSCANDATE] [--updatedChConfig]
                     [-v VFATCONFIGSCANDATE]

Arguments to supply to updateConf.py

optional arguments:
  -h, --help            show this help message and exit
  -d, --debug           prints additional debugging information
  -c CHCONFIGSCANDATE, --chConfigScandate CHCONFIGSCANDATE
                        Scandate in YYYY.MM.DD.hh.mm format, or the string
                        'current', for the scurve measurement to take chConfig
                        from for all detectors
  --updatedChConfig     The 'chConfigScandate' argument is understood to come
                        from an updated chConfig produced with joint analysis
                        of scurve and tracking data threshold scan
                        measurements; here the scandate is understood as the
                        date of the tracking data threshold scan
  -v VFATCONFIGSCANDATE, --vfatConfigScandate VFATCONFIGSCANDATE
                        Scandate in YYYY.MM.DD.hh.mm format, or the string
                        'current', for SBIT Threshold measurement to take
                        vfatConfig from for all detectors
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
