### PR TITLE
New Feature: Now updateConf.py can set chConfig  from a trim run (Addressing issue #43)

### DIFF
--- a/python/updateConf.py
+++ b/python/updateConf.py
@@ -9,13 +9,15 @@ updateNewConf.py
 
 from gempython.utils.gemlogger import printYellow, printRed
 
-def getChConfigFileDict(chamber_config, scandate, debug=False, takeFromSCurve=True):
+def getChConfigFileDict(chamber_config, scandate, debug=False, takeFromSCurve=True, isTrimScandate=False):
     """
     Returns a dictionary of chConfig files.
 
     chamber_config  - Dictionary whose key values are geographic address, e.g. (shelf,slot,link), and values are detector serial numbers
     scandate        - Either None or a string specifying the scandate of the files of interest, in YYYY.MM.DD.hh.mm format
     debug           - Prints debugging information if True
+    takeFromSCurve  - chConfig file comes from an scurve measurement (e.g. either scurve or trim)
+    isTrimScandate  - chConfig file should come from a trim scandate; no effect if takeFromSCurve is False
     """
     fileDict = {}
 
@@ -25,7 +27,10 @@ def getChConfigFileDict(chamber_config, scandate, debug=False, takeFromSCurve=Tr
     listOfFoundFiles = [ ]
     for geoAddr,cName in chamber_config.iteritems():
         if takeFromSCurve:
-            filename = "{}/{}/SCurveData/chConfig.txt".format(getDirByAnaType("scurve",cName),scandate)
+            if isTrimScandate:
+                filename = "{}/{}/chConfig.txt".format(getDirByAnaType("trimV3",cName),scandate)
+            else:
+                filename = "{}/{}/SCurveData/chConfig.txt".format(getDirByAnaType("scurve",cName),scandate)
         else:
             filename = "{}/{}/ThresholdScanData/chConfig_MasksUpdated.txt".format(getDirByAnaType("thresholdch",cName),scandate)
 
@@ -74,8 +79,12 @@ if __name__ == '__main__':
 
     parser.add_argument("-d","--debug",action="store_true",help="prints additional debugging information")
     parser.add_argument("-c","--chConfigScandate",type=str,help="Scandate in YYYY.MM.DD.hh.mm format, or the string 'current', for the scurve measurement to take chConfig from for all detectors",default=None)
-    parser.add_argument("--updatedChConfig",action="store_true",help="The 'chConfigScandate' argument is understood to come from an updated chConfig produced with joint analysis of scurve and tracking data threshold scan measurements; here the scandate is understood as the date of the tracking data threshold scan")
     parser.add_argument("-v","--vfatConfigScandate",type=str,help="Scandate in YYYY.MM.DD.hh.mm format, or the string 'current', for SBIT Threshold measurement to take vfatConfig from for all detectors",default=None)
+
+    chConfigGroup = parser.add_mutually_exclusive_group(required=False)
+    chConfigGroup.add_argument("-u","--updatedChConfig",action="store_true",help="The 'chConfigScandate' argument is understood to come from an updated chConfig produced with joint analysis of scurve and tracking data threshold scan measurements; here the scandate is understood as the date of the tracking data threshold scan")
+    chConfigGroup.add_argument("-t","--trimChConfig",action="store_true",help="The 'chConfigScandate' argument is understood to be the scandate of a trim run")
+
     args = parser.parse_args()
 
     from gempython.gemplotting.utils.anautilities import getDataPath
@@ -93,7 +102,7 @@ if __name__ == '__main__':
         printRed("No scandates provided for either chConfig or vfatConfig. Nothing to do, exiting")
         sys.exit(os.EX_USAGE)
     if args.chConfigScandate is not None:
-        chConfigDict = getChConfigFileDict(chamber_config, args.chConfigScandate, args.debug, not args.updatedChConfig)
+        chConfigDict = getChConfigFileDict(chamber_config, args.chConfigScandate, args.debug, not args.updatedChConfig,args.trimChConfig)
         for cName,chConfig in chConfigDict.iteritems():
             cmd = ["ln","-sf",chConfig,"{}/configs/chConfig_{}.txt".format(dataPath,cName)]
             runCommand(cmd)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addressing issue #43 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
#43 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated help menu:

```bash
% python updateConf.py -h
usage: updateConf.py [-h] [-d] [-c CHCONFIGSCANDATE] [-v VFATCONFIGSCANDATE]
                     [-u | -t]

Arguments to supply to updateConf.py

optional arguments:
  -h, --help            show this help message and exit
  -d, --debug           prints additional debugging information
  -c CHCONFIGSCANDATE, --chConfigScandate CHCONFIGSCANDATE
                        Scandate in YYYY.MM.DD.hh.mm format, or the string
                        'current', for the scurve measurement to take chConfig
                        from for all detectors
  -v VFATCONFIGSCANDATE, --vfatConfigScandate VFATCONFIGSCANDATE
                        Scandate in YYYY.MM.DD.hh.mm format, or the string
                        'current', for SBIT Threshold measurement to take
                        vfatConfig from for all detectors
  -u, --updatedChConfig
                        The 'chConfigScandate' argument is understood to come
                        from an updated chConfig produced with joint analysis
                        of scurve and tracking data threshold scan
                        measurements; here the scandate is understood as the
                        date of the tracking data threshold scan
  -t, --trimChConfig    The 'chConfigScandate' argument is understood to be
                        the scandate of a trim run
```

Usage example:

```bash
updateConf.py -c 2019.08.01.12.34 -t
```

This will take the `chConfig.txt` file for all chambers in `chamber_config` from the trim run with scandate `2019.08.01.12.34`

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
